### PR TITLE
[DEVEDSB-98] Add ErrorPageErrorHandler to work with /error route

### DIFF
--- a/src/main/java/com/twilio/notifications/WebServer.java
+++ b/src/main/java/com/twilio/notifications/WebServer.java
@@ -3,6 +3,7 @@ package com.twilio.notifications;
 import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,11 @@ public class WebServer {
 
     private static ServletContextHandler getServletContextHandler(WebApplicationContext context) throws IOException {
         ServletContextHandler contextHandler = new ServletContextHandler();
-        contextHandler.setErrorHandler(null);
+        ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
+        errorHandler.addErrorPage(404, "/error");
+        errorHandler.addErrorPage(500, "/error");
+        errorHandler.addErrorPage(503, "/error");
+        contextHandler.setErrorHandler(errorHandler);
         contextHandler.setContextPath(CONTEXT_PATH);
         contextHandler.addServlet(new ServletHolder(new DispatcherServlet(context)), MAPPING_URL);
         contextHandler.addEventListener(new ContextLoaderListener(context));


### PR DESCRIPTION
An ErrorPageErrorHandler was missing in order to have the Error handler working with 404 500 and 503 error in the example